### PR TITLE
two decimal places answer

### DIFF
--- a/linear-regression/index.js
+++ b/linear-regression/index.js
@@ -57,7 +57,7 @@ function f(s) {
 
 function predictOutput() {
     rl.question('Enter input X for prediction (Press CTRL+C to exit) : ', (answer) => {
-        console.log(`At X = ${answer}, y =  ${regressionModel.predict(parseFloat(answer))}`);
+        console.log(`At X = ${answer}, y =  ${regressionModel.predict(parseFloat(answer)).toFixed(2)}`);
         predictOutput();
     });
 }


### PR DESCRIPTION
Added `toFixed(2)` to the console output of the y value outputted for a given user input.
This keeps the y output in console to a maximum of 2 decimal places for cleaner viewing.